### PR TITLE
Add continous integration support using Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: c
+compiler:
+  - clang
+  - gcc
+os:
+  - linux
+before_install: "autoreconf -vfi"
+install: "./configure && make"


### PR DESCRIPTION
Add support for continuous integration using [Travis CI](https://travis-ci.org/), a managed CI solution