### PR TITLE
Build fixes: ifr_index/ifindex, unicast neg mgmt message display

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -196,6 +196,12 @@ AC_CHECK_MEMBERS([struct ntptimeval.tai], [], [],
 # Check for ifr_hwaddr in the ifreq structure
 AC_CHECK_MEMBERS([struct ifreq.ifr_hwaddr], [], [], [[#include <net/if.h>]])
 
+# Check for ifr_index in the ifreq structure
+AC_CHECK_MEMBERS([struct ifreq.ifr_index], [], [], [[#include <net/if.h>]])
+
+# Check for ifr_ifindex in the ifreq structure
+AC_CHECK_MEMBERS([struct ifreq.ifr_ifindex], [], [], [[#include <net/if.h>]])
+
 # ether_add: octet vs. ether_addr_octet - FreeBSD, any others?
 AC_CHECK_MEMBERS([struct ether_addr.octet], [], [],
 [

--- a/src/dep/net.c
+++ b/src/dep/net.c
@@ -434,8 +434,15 @@ static int getInterfaceIndex(char *ifaceName)
 
     }
 
+#if defined(HAVE_STRUCT_IFREQ_IFR_INDEX)
+    return ifr.ifr_index;
+#elif defined(HAVE_STRUCT_IFREQ_IFR_IFINDEX)
     return ifr.ifr_ifindex;
+#else
+    return 0;
 #endif
+
+#endif /* !SIOCGIFINDEX */
 
 }
 

--- a/src/ptpd.h
+++ b/src/ptpd.h
@@ -443,7 +443,7 @@ void mMClockAccuracy_display(const MMClockAccuracy*, const PtpClock*);
 void mMUtcProperties_display(const MMUtcProperties*, const PtpClock*);
 void mMTraceabilityProperties_display(const MMTraceabilityProperties*, const PtpClock*);
 void mMTimescaleProperties_display(const MMTimescaleProperties*, const PtpClock*);
-void mMUnicastNegotiationEnable(const MMUnicastNegotiationEnable*, const PtpClock*);
+void mMUnicastNegotiationEnable_display(const MMUnicastNegotiationEnable*, const PtpClock*);
 void mMDelayMechanism_display(const MMDelayMechanism*, const PtpClock*);
 void mMLogMinPdelayReqInterval_display(const MMLogMinPdelayReqInterval*, const PtpClock*);
 void mMErrorStatus_display(const MMErrorStatus*, const PtpClock*);


### PR DESCRIPTION
- checks for ifr_index vs. ifr_ifindex
- missing _enable in mMUnicastNegotiationEnable_display declaration
