### PR TITLE
Removes dead writing function declarations.

### DIFF
--- a/src/dep/ptpd_dep.h
+++ b/src/dep/ptpd_dep.h
@@ -416,8 +416,6 @@ void stepClock(const RunTimeOpts * rtOpts, PtpClock * ptpClock);
  * -Handle with runtime options*/
  /**\{*/
 int setCpuAffinity(int cpu);
-int logToFile(RunTimeOpts * rtOpts);
-int recordToFile(RunTimeOpts * rtOpts);
 PtpClock * ptpdStartup(int,char**,Integer16*,RunTimeOpts*);
 
 void ptpdShutdown(PtpClock * ptpClock);


### PR DESCRIPTION
Came across these dead function declarations while debugging an error I had with PTPD 2.1.0.