### PR TITLE
Use /usr/bin/env to make the scripts more portable.

### DIFF
--- a/tools/compare.R
+++ b/tools/compare.R
@@ -1,4 +1,4 @@
-#!/usr/local/bin/Rscript --slave
+#!/usr/bin/env Rscript
 # Copyright (c) 2013, Neville-Neil Consulting
 # All rights reserved.
 #

--- a/tools/graph.R
+++ b/tools/graph.R
@@ -1,4 +1,4 @@
-#!/usr/local/bin/Rscript --slave
+#!/usr/bin/env Rscript
 # Copyright (c) 2016, Neville-Neil Consulting
 # All rights reserved.
 #

--- a/tools/ntpoffset.R
+++ b/tools/ntpoffset.R
@@ -1,4 +1,4 @@
-#!/usr/local/bin/Rscript --slave
+#!/usr/bin/env Rscript
 # Copyright (c) 2016, Neville-Neil Consulting
 # All rights reserved.
 #

--- a/tools/offset.R
+++ b/tools/offset.R
@@ -1,4 +1,4 @@
-#!/usr/local/bin/Rscript --slave
+#!/usr/bin/env Rscript
 # Copyright (c) 2016, Neville-Neil Consulting
 # All rights reserved.
 #

--- a/tools/stats.R
+++ b/tools/stats.R
@@ -1,4 +1,4 @@
-#!/usr/local/bin/Rscript --slave
+#!/usr/bin/env Rscript
 # Copyright (c) 2016, Neville-Neil Consulting
 # All rights reserved.
 #


### PR DESCRIPTION
In addition, remove --script, as I believe that is not necessary when
using Rscript instead of R.  In my tests, they produced the exact same
output, but with these changes I was able to run the R scripts directly
instead of needing to pass them as an argument to Rscript, as my Rscript
is at /usr/bin/Rscript.