### PR TITLE
rpm-rh: support adding a git-based tag and ptpd2 as service name

### DIFF
--- a/packagebuild/rpm-rh/ptpd.init
+++ b/packagebuild/rpm-rh/ptpd.init
@@ -18,9 +18,9 @@ DAEMON_DESC="IEEE 1588 Precision Time Protocol (v2) daemon"
 
 . /etc/init.d/functions
 
-if test -e /etc/sysconfig/ptpd ; then
+if test -e /etc/sysconfig/__SERVICENAME__ ; then
 
-    . /etc/sysconfig/ptpd
+    . /etc/sysconfig/__SERVICENAME__
     
     PTPD_OPTIONS="--global:lock_file=$PTPD_PID_FILE --global:status_file=$PTPD_STATUS_FILE -c $PTPD_CONFIG_FILE $PTPD_EXTRA_OPTIONS"
 

--- a/packagebuild/rpm-rh/ptpd.service
+++ b/packagebuild/rpm-rh/ptpd.service
@@ -4,7 +4,7 @@ After=syslog.target ntpdate.service sntp.service ntp.service chronyd.service net
 
 [Service]
 Type=forking
-EnvironmentFile=-/etc/sysconfig/ptpd
+EnvironmentFile=-/etc/sysconfig/__SERVICENAME__
 ExecStart=/usr/sbin/ptpd2 \
     --global:lock_file=${PTPD_PID_FILE} \
     --global:status_file=${PTPD_STATUS_FILE} \

--- a/packagebuild/rpm-rh/ptpd.spec
+++ b/packagebuild/rpm-rh/ptpd.spec
@@ -23,7 +23,7 @@ Name: ptpd
 Summary: Synchronises system time using the Precision Time Protocol (PTP) implementing the IEEE 1588-2008 (PTP v 2) standard. Full version with master and slave support.
 %endif
 Version: 2.3.2
-Release: 1%{distver}
+Release: 1%{distver}%{?gittag}
 License: distributable
 Group: System Environment/Daemons
 Vendor: PTPd project team

--- a/packagebuild/rpm-rh/ptpd.spec
+++ b/packagebuild/rpm-rh/ptpd.spec
@@ -15,6 +15,8 @@
 %define distver %(/usr/lib/rpm/redhat/dist.sh --dist)
 %endif
 
+%define servicename ptpd%{?servicesuffix}
+
 %if %{slaveonly_build} == 1
 Name: ptpd-slaveonly
 Summary: Synchronises system time using the Precision Time Protocol (PTP) implementing the IEEE 1588-2008 (PTP v 2) standard. Slave-only version.
@@ -66,7 +68,7 @@ coordination of LAN connected computers.
 Install the ptpd package if you need tools for keeping your system's
 time synchronised via the PTP protocol or serving PTP time.
 
-%prep 
+%prep
 
 %setup -n ptpd-2.3.2
 
@@ -104,14 +106,16 @@ install -m 644 src/templates.conf $RPM_BUILD_ROOT%{_datadir}/ptpd/templates.conf
 
 %if %{?_unitdir:1}%{!?_unitdir:0}
   mkdir -p .%{_unitdir}
-  install -m644 $RPM_SOURCE_DIR/ptpd.service .%{_unitdir}/ptpd.service
+  install -m644 $RPM_SOURCE_DIR/ptpd.service .%{_unitdir}/%{servicename}.service
+  sed -i 's#/etc/sysconfig/__SERVICENAME__#/etc/sysconfig/%{servicename}#' .%{_unitdir}/%{servicename}.service
 %else
   mkdir -p .%{_initrddir}
-  install -m755 $RPM_SOURCE_DIR/ptpd.init .%{_initrddir}/ptpd
+  install -m755 $RPM_SOURCE_DIR/ptpd.init .%{_initrddir}/%{servicename}
+  sed -i 's#/etc/sysconfig/__SERVICENAME__#/etc/sysconfig/%{servicename}#' .%{_initrddir}/%{servicename}
 %endif
 
   mkdir -p .%{_sysconfdir}/sysconfig
-  install -m644 %{SOURCE2} .%{_sysconfdir}/sysconfig/ptpd
+  install -m644 %{SOURCE2} .%{_sysconfdir}/sysconfig/%{servicename}
   install -m644 %{SOURCE3} .%{_sysconfdir}/ptpd2.conf
 
 }
@@ -125,9 +129,9 @@ rm -rf $RPM_BUILD_ROOT
 %post
 
 %if %{?_unitdir:1}%{!?_unitdir:0}
-/usr/bin/systemctl enable ptpd  >/dev/null 2>&1
+/usr/bin/systemctl enable %{servicename} >/dev/null 2>&1
 %else
-/sbin/chkconfig --add ptpd
+/sbin/chkconfig --add %{servicename}
 %endif
 echo
 echo -e "**** PTPd - Running post-install checks...\n"
@@ -185,18 +189,18 @@ done
 %preun
 if [ $1 = 0 ]; then
 %if %{?_unitdir:1}%{!?_unitdir:0}
-systemctl stop ptpd > /dev/null 2>&1
-systemctl disable ptpd  >/dev/null 2>&1
+systemctl stop %{servicename} > /dev/null 2>&1
+systemctl disable %{servicename}  >/dev/null 2>&1
 %else
-    service ptpd stop > /dev/null 2>&1
-    /sbin/chkconfig --del ptpd
+    service %{servicename} stop > /dev/null 2>&1
+    /sbin/chkconfig --del %{servicename}
 %endif
 fi
 :
 
 %postun
 if [ "$1" -ge "1" ]; then
-  service ptpd condrestart > /dev/null 2>&1
+  service %{servicename} condrestart > /dev/null 2>&1
 fi
 :
 
@@ -204,11 +208,11 @@ fi
 %defattr(-,root,root)
 %{_sbindir}/ptpd2
 %if %{?_unitdir:1}%{!?_unitdir:0}
-%{_unitdir}/ptpd.service
+%{_unitdir}/%{servicename}.service
 %else
-%config			%{_initrddir}/ptpd
+%config			%{_initrddir}/%{servicename}
 %endif
-%config(noreplace)	%{_sysconfdir}/sysconfig/ptpd
+%config(noreplace)	%{_sysconfdir}/sysconfig/%{servicename}
 %config(noreplace)	%{_sysconfdir}/ptpd2.conf
 %config(noreplace)	%{_datadir}/ptpd/templates.conf
 %{_mandir}/man8/*

--- a/packagebuild/rpm-rh/rpmbuild.sh
+++ b/packagebuild/rpm-rh/rpmbuild.sh
@@ -1,57 +1,75 @@
 #!/bin/sh
 
+if [ ! -z "$DEBUG" ]; then
+    set -x
+fi
+
 # ptpd RPM building script
 # (c) 2013-2015: Wojciech Owczarek, PTPd project
 
-# build both versions: normal and slave-only
+# First argument: 1/0 to add a git tag (timestamp.lastgitcommit)
+ADD_TAG=${1:-0}
+
 SPEC=ptpd.spec
-rm *.rpm
-for slaveonly in 0 1; do
-
 PWD=`pwd`
-BUILDDIR=`mktemp -d /tmp/tmpbuild.XXXXXXXXX`
+if [ `basename $PWD` != 'rpm-rh' ]; then
+    # deleting rpm is dangerous
+    echo "Can only be run from packagebuild/rpm-rh subdir in repo"
+    exit 1
+fi
+rm *.rpm
 
-
-rm -rf $BUILDDIR
-
-rpm -q rpm-build --quiet || { echo "Error: rpm-build not installed"; exit 1; }
-rpm -q libpcap-devel --quiet || { echo "Error: libpcap-devel not installed"; exit 1; }
-
-
-
-
-for dir in BUILD BUILDROOT RPMS SOURCES SPECS SRPMS; do mkdir -p $BUILDDIR/$dir; done
-
-
-TARBALL=`cat $SPEC | grep ^Source0 | awk '{ print $2; }'`
-
-# hack: dist hook now removes rpms from this dir before dist packaging:
-# this is how we preserve them...
-mv *.rpm ../..
-( cd ../..; autoreconf -vi; ./configure; make dist; )
-# and in they go again...
-mv ../../*.rpm .
-
-mv ../../$TARBALL .
-
-for sourcefile in `grep ^Source $SPEC | awk '{print $2;}'`; do
-
-    cp -f $sourcefile $BUILDDIR/SOURCES
-
+for dep in rpm-build `grep BuildRequires ptpd.spec | sed "s/^.*: //" |grep -v systemd | tr '\n' ' '`; do
+    rpm -q $dep --quiet || { echo "Error: $dep not installed"; exit 1; }
 done
 
-cp -f $SPEC $BUILDDIR/SPECS
+# build both versions: normal and slave-only
+for slaveonly in 0 1; do
 
-ARCHIVE=`cat $SPEC | egrep "Name|Version|Release" | awk 'BEGIN {ORS="-";} NR<3 { print $2;} NR>=3 {ORS=""; print $2}'`
-RPMFILE=$BUILDDIR/RPMS/`uname -m`/$ARCHIVE.`uname -m`.rpm
-SRPMFILE=$BUILDDIR/SRPMS/$ARCHIVE.src.rpm
+    cd $PWD
+    BUILDDIR=`mktemp -d /tmp/tmpbuild.XXXXXXXXX`
+
+    rm -rf $BUILDDIR
 
 
-rpmbuild  --define "build_slaveonly $slaveonly" --define "_topdir $BUILDDIR" -ba $BUILDDIR/SPECS/$SPEC && { 
-    find $BUILDDIR -name "*.rpm" -exec mv {} $PWD \;
-}
+    for dir in BUILD BUILDROOT RPMS SOURCES SPECS SRPMS; do
+        mkdir -p $BUILDDIR/$dir;
+    done
 
-rm -rf $BUILDDIR
-rm $TARBALL
 
+    TARBALL=`cat $SPEC | grep ^Source0 | awk '{ print $2; }'`
+
+    # hack: dist hook now removes rpms from this dir before dist packaging:
+    # this is how we preserve them...
+    mv *.rpm ../..
+    ( cd ../..; autoreconf -vi; ./configure; make dist; )
+    # and in they go again...
+    mv ../../*.rpm .
+
+    mv ../../$TARBALL .
+
+    for sourcefile in `grep ^Source $SPEC | awk '{print $2;}'`; do
+        cp -f $sourcefile $BUILDDIR/SOURCES
+    done
+
+    cp -f $SPEC $BUILDDIR/SPECS
+
+    ARCHIVE=`cat $SPEC | egrep "Name|Version|Release" | awk 'BEGIN {ORS="-";} NR<3 { print $2;} NR>=3 {ORS=""; print $2}'`
+    RPMFILE=$BUILDDIR/RPMS/`uname -m`/$ARCHIVE.`uname -m`.rpm
+    SRPMFILE=$BUILDDIR/SRPMS/$ARCHIVE.src.rpm
+
+    TAG_ARG=''
+    if [ $ADD_TAG -ne 0 ]; then
+        tag=`git log --format=.%ct.%h -1` # based on last commit, timestamp for increasing versions
+        TAG_ARG="gittag $tag"
+    fi
+
+    rpmbuild --define "$TAG_ARG" --define "build_slaveonly $slaveonly" --define "_topdir $BUILDDIR" -ba $BUILDDIR/SPECS/$SPEC && {
+        find $BUILDDIR -name "*.rpm" -exec mv {} $PWD \;
+    }
+
+    rm -rf $BUILDDIR
+    rm $TARBALL
+
+    echo "Moved rpms to $PWD"
 done


### PR DESCRIPTION
when you build the rpms with `./rpmbuild.sh --tag`, it now makes rpms like `ptpd-2.3.2-1.el6.1466165333.fb3ef76.x86_64.rpm`

the tag format is `<timestamp of last commit>.<short last commit hash>`

if you use the `--service2` option, it will generate a `ptpd2` service (instead of default `ptpd`)