### PR TITLE
Solve issue #25 - Removing type U64 from net-snmp related code

### DIFF
--- a/src/dep/snmp.c
+++ b/src/dep/snmp.c
@@ -390,7 +390,7 @@ snmpHeaderIndexBest(struct snmpHeaderIndex *idx)
 
 #define SNMP_LOCAL_VARIABLES			\
 	static unsigned long long_ret;		\
-	static U64 counter64_ret;		\
+	static struct counter64 counter64_ret;	\
 	static uint32_t ipaddr;			\
 	Integer32 i32_ret;			\
 	Integer64 bigint;			\
@@ -1846,7 +1846,7 @@ populateNotif (netsnmp_variable_list** varBinds, int eventType, PtpEventData *ev
 		case PTPBASE_NOTIFS_SLAVE_OFFSET_THRESHOLD_EXCEEDED:
 		case PTPBASE_NOTIFS_SLAVE_OFFSET_THRESHOLD_ACCEPTABLE:
 		    {
-			U64 ofmNum;
+			struct counter64 ofmNum;
 			Integer64  tmpi64;
 			internalTime_to_integer64(eventData->currentDS.offsetFromMaster, &tmpi64);
 			ofmNum.low = htonl(tmpi64.lsb);
@@ -1933,7 +1933,7 @@ populateNotif (netsnmp_variable_list** varBinds, int eventType, PtpEventData *ev
 		case PTPBASE_NOTIFS_OFFSET_SECONDS:
 		case PTPBASE_NOTIFS_OFFSET_SUB_SECONDS:
 		    {
-			U64 ofmNum;
+			struct counter64 ofmNum;
 			Integer64  tmpi64;
 			internalTime_to_integer64(eventData->currentDS.offsetFromMaster, &tmpi64);
 			ofmNum.low = htonl(tmpi64.lsb);


### PR DESCRIPTION
Solving issue #25 

`U64` was just a typedef of `struct counter64`. This typedef will be removed in future versions of net-snmp because of conflict with perl. `struct counter64` was there and will be there so this patch should be backward compatible and it should compile seemlessly with any version of net-snmp.