### PR TITLE
Ensure returned address is the one of a static variable

### DIFF
--- a/src/dep/snmp.c
+++ b/src/dep/snmp.c
@@ -395,7 +395,7 @@ snmpHeaderIndexBest(struct snmpHeaderIndex *idx)
 	Integer32 i32_ret;			\
 	Integer64 bigint;			\
 	struct snmpHeaderIndex idx;		\
-	char tmpStr[64];			\
+	static char tmpStr[64];			\
 	(void)long_ret;				\
 	(void)counter64_ret;			\
 	(void)ipaddr;				\


### PR DESCRIPTION
In snmp.c, when returning the address of a variable, we must ensure the
variable is a static one so that its content is not erased when leaving
the function scope.
