### PR TITLE
fix PTP_PASSIVE when behind the switch

### DIFF
--- a/src/protocol.c
+++ b/src/protocol.c
@@ -1732,6 +1732,13 @@ handleAnnounce(MsgHeader *header, ssize_t length,
 			msgUnpackAnnounce(ptpClock->msgIbuf,
 					  &ptpClock->msgTmp.announce);
 
+            /*
+             * Update all information about master every announce
+             * If it's behind the switch and active master dies, IP doesn't change but priority does
+             */
+			memcpy(&ptpClock->bestMaster->announce,
+			       &ptpClock->msgTmp.announce,sizeof(MsgAnnounce));
+
 			/* TODO: not in spec
 			 * datasets should not be updated by another master
 			 * this is the reason why we are PASSIVE and not SLAVE


### PR DESCRIPTION
We have Cisco Nexus switches which distributes PTP, and PTP masters are behind them. Switches works as masterslave, so when Active master dies, one of them starts to broadcast as Active Master. 

Because original PTP active master is behind Cisco Nexus, it can see only IP of the switch, which doesn't change when Nexus starts to broadcast as Active Master. But it broadcast worst possible priority and class, and thats what should Passive Master check so he can become Active Master. There's check for that, but only when PTPd is starting.