### PR TITLE
ntp_isc_md5: rename EVP_MD_CTX into EVP_MD5_CTX

### DIFF
--- a/src/dep/ntpengine/ntp_isc_md5.c
+++ b/src/dep/ntpengine/ntp_isc_md5.c
@@ -262,7 +262,7 @@ MD5authencrypt(
 {
 	u_char	digest[64];
 	u_int	len;
-	EVP_MD_CTX ctx;
+	EVP_MD5_CTX ctx;
         pkt[length / 4] = htonl(keyid);
 	EVP_DigestInit(&ctx);
 	EVP_DigestUpdate(&ctx, (u_char *)key, (u_int)strlen(key));

--- a/src/dep/ntpengine/ntp_isc_md5.h
+++ b/src/dep/ntpengine/ntp_isc_md5.h
@@ -80,7 +80,7 @@ isc_md5_final(isc_md5_t *ctx, unsigned char *digest);
 # define MD5Init(c)             isc_md5_init(c)
 # define MD5Update(c, p, s)     isc_md5_update(c, p, s)
 # define MD5Final(d, c)         isc_md5_final((c), (d)) /* swapped */
-  typedef MD5_CTX                       EVP_MD_CTX;
+  typedef MD5_CTX                       EVP_MD5_CTX;
 # define EVP_DigestInit(c)              MD5Init(c)
 # define EVP_DigestUpdate(c, p, s)      MD5Update(c, p, s)
 # define EVP_DigestFinal(c, d, pdl)     \


### PR DESCRIPTION
EVP_MD_CTX can conflict with openssl that defines a completely different
typedef with same name.

Since this typedef is used only twice in the entire ptpd,
substitute EVP_MD_CTX with EVP_MD5_CTX.

Signed-off-by: Giulio Benetti <giulio.benetti@micronovasrl.com>